### PR TITLE
curl: add -h cheat-sheet using curl-cheat-sheet as text

### DIFF
--- a/docs/cmdline-opts/help.md
+++ b/docs/cmdline-opts/help.md
@@ -23,11 +23,13 @@ Usage help. Provide help for the subject given as an optional argument.
 If no argument is provided, curl displays the most important command line
 arguments.
 
-The argument can either be a **category** or a **command line option**. When a
-category is provided, curl shows all command line options within the given
-category. Specify category `all` to list all available options.
+The argument can either be a **category**, a **command line option**, or
+**cheat-sheet**. When a category is provided, curl shows all command line
+options within the given category. Specify category `all` to list all
+available options.
 
 If `category` is specified, curl displays all available help categories.
+If `cheat-sheet` is specified, curl displays a helpful cheat sheet.
 
 If the provided subject is instead an existing command line option, specified
 either in its short form with a single dash and a single letter, or in the

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -233,6 +233,7 @@ void tool_help(const char *category)
       "Use \"--help all\" to list all options"
 #ifdef USE_MANUAL
       "\nUse \"--help [option]\" to view documentation for a given option"
+      "\nUse \"--help cheat-sheet\" to output a helpful cheat sheet"
 #endif
       ;
     puts("Usage: curl [options...] <url>");

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -226,7 +226,7 @@ test1670 test1671 \
 test1680 test1681 test1682 test1683 \
 \
 test1700 test1701 test1702 test1703 test1704 test1705 test1706 test1707 \
-test1708 test1709 test1710 \
+test1708 test1709 test1710 test1711 \
 \
 test1800 test1801 \
 \

--- a/tests/data/test1461
+++ b/tests/data/test1461
@@ -55,6 +55,7 @@ output, pop3, post, proxy, scp, sftp, smtp, ssh, telnet, tftp, timeout, tls,
 upload, verbose.
 Use "--help all" to list all options
 Use "--help [option]" to view documentation for a given option
+Use "--help cheat-sheet" to output a helpful cheat sheet
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test1711
+++ b/tests/data/test1711
@@ -1,0 +1,34 @@
+<testcase>
+<info>
+<keywords>
+curl
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<features>
+manual
+</features>
+<server>
+none
+</server>
+
+<name>
+Verify curl -h cheat-sheet
+</name>
+
+<command>
+-h cheat-sheet
+</command>
+</client>
+
+#
+# Verify no error
+<verify>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Update documentation and add test for proposed  `cheat-sheet` argument for `--help` option.